### PR TITLE
Monitor Release GA verison

### DIFF
--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -1,6 +1,10 @@
 # DocuSign Monitor C# Client Changelog
 See [DocuSign Support Center](https://support.docusign.com/en/releasenotes/) for Product Release Notes.
 
+## [v1.0.0] - DocuSign Monitor API v2.0-1.0.1 - 06/28/2021
+### Changed
+- First GA version of Monitor API.
+
 ## [v1.0.0-beta] - DocuSign Monitor API v2.0-1.0.1 - 05/17/2021
 ### Changed
 - First Beta version of Monitor API.

--- a/sdk/src/DocuSign.Monitor/Client/Configuration.cs
+++ b/sdk/src/DocuSign.Monitor/Client/Configuration.cs
@@ -26,7 +26,7 @@ namespace DocuSign.Monitor.Client
         /// Version of the package.
         /// </summary>
         /// <value>Version of the package.</value>
-        public const string Version = "1.0.0-beta";
+        public const string Version = "1.0.0";
 
         /// <summary>
         /// Identifier for ISO 8601 DateTime Format

--- a/sdk/src/DocuSign.Monitor/DocuSign.Monitor.csproj
+++ b/sdk/src/DocuSign.Monitor/DocuSign.Monitor.csproj
@@ -24,7 +24,7 @@ Contact: devcenter@docusign.com
     <RootNamespace>DocuSign.Monitor</RootNamespace>
     <AssemblyName>DocuSign.Monitor</AssemblyName>
     <NeutralLanguage>en-US</NeutralLanguage>
-    <VersionPrefix>1.0.0-beta</VersionPrefix>
+    <VersionPrefix>1.0.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -34,9 +34,7 @@ Contact: devcenter@docusign.com
     <PackageLicenseUrl>https://github.com/docusign/docusign-csharp-client/blob/master/LICENSE</PackageLicenseUrl>
     <RepositoryUrl>https://github.com/docusign/docusign-csharp-client</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <PackageReleaseNotes>[1.0.0-beta] - DocuSign Monitor API v2.0-1.0.1 - 05/17/2021</PackageReleaseNotes>
-    <SignAssembly>true</SignAssembly>
-    <AssemblyOriginatorKeyFile>DocuSignClient.snk</AssemblyOriginatorKeyFile>
+    <PackageReleaseNotes>[1.0.0] - DocuSign Monitor API v2.0-1.0.1 - 06/28/2021</PackageReleaseNotes>
   </PropertyGroup>
 
   <!-- .NET Framework 4.5.2 compilation flags and build options -->

--- a/sdk/src/DocuSign.Monitor/DocuSign.Monitor.nuspec
+++ b/sdk/src/DocuSign.Monitor/DocuSign.Monitor.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>DocuSign.Monitor</id>
-    <version>1.0.0-beta</version>
+    <version>1.0.0</version>
     <title>DocuSign.Monitor</title>
     <authors>DocuSign</authors>
     <owners>DocuSign</owners>

--- a/sdk/src/DocuSign.Monitor/Properties/AssemblyInfo.cs
+++ b/sdk/src/DocuSign.Monitor/Properties/AssemblyInfo.cs
@@ -22,5 +22,5 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 internal class AssemblyInformation
 {
-    public const string AssemblyInformationalVersion = "1.0.0-beta";
+    public const string AssemblyInformationalVersion = "1.0.0";
 }


### PR DESCRIPTION
## [v1.0.0] - DocuSign Monitor API v2.0-1.0.1 - 06/28/2021
### Changed
- First GA version of Monitor API.