### PR TITLE
Version 2.0.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [v2.0.2] - Monitor API v2.0-2.0.0 - 2024-11-15
+### Changed
+- Resolved an issue that prevented the use of `RequestJWTApplicationToken` with a production account URL.
+- Updated C# SDK dependencies.
+    - BouncyCastle.Cryptography: Version bumped from 2.3.1 to 2.4.0.
+    - Microsoft.IdentityModelJsonWebTokens: Version bumped from 7.5.2 to 8.2.0.
+- Updated the SDK release version.
+
 ## [v2.0.1] - Monitor API v2.0-2.0.0 - 2024-11-07
 ### Changed
 - Fixed Deadlock issue with UI Apps (E.g. WinForms).

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ This client SDK is provided as open source, which enables you to customize its f
 <a id="versionInformation"></a>
 ### Version Information
 - **API version**: v2.0
-- **Latest SDK version (Including prerelease)**: 2.0.1
+- **Latest SDK version (Including prerelease)**: 2.0.2
 
 <a id="requirements"></a>
 ### Requirements

--- a/sdk/DocuSign.Monitor.sln
+++ b/sdk/DocuSign.Monitor.sln
@@ -2,7 +2,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2012
 VisualStudioVersion = 12.0.0.0
 MinimumVisualStudioVersion = 10.0.0.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DocuSign.Monitor", "src\DocuSign.Monitor\DocuSign.Monitor.csproj", "{E27A81DE-E018-4C9F-82E6-2EA8D43529DA}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DocuSign.Monitor", "src\DocuSign.Monitor\DocuSign.Monitor.csproj", "{6AD11A36-FBF2-4186-9FCF-3704138B7D41}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -10,10 +10,10 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{E27A81DE-E018-4C9F-82E6-2EA8D43529DA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{E27A81DE-E018-4C9F-82E6-2EA8D43529DA}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{E27A81DE-E018-4C9F-82E6-2EA8D43529DA}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{E27A81DE-E018-4C9F-82E6-2EA8D43529DA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6AD11A36-FBF2-4186-9FCF-3704138B7D41}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6AD11A36-FBF2-4186-9FCF-3704138B7D41}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6AD11A36-FBF2-4186-9FCF-3704138B7D41}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6AD11A36-FBF2-4186-9FCF-3704138B7D41}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/sdk/src/DocuSign.Monitor/Client/Configuration.cs
+++ b/sdk/src/DocuSign.Monitor/Client/Configuration.cs
@@ -26,7 +26,7 @@ namespace DocuSign.Monitor.Client
         /// Version of the package.
         /// </summary>
         /// <value>Version of the package.</value>
-        public const string Version = "2.0.1";
+        public const string Version = "2.0.2";
 
         /// <summary>
         /// Identifier for ISO 8601 DateTime Format

--- a/sdk/src/DocuSign.Monitor/Client/DocuSignClient.cs
+++ b/sdk/src/DocuSign.Monitor/Client/DocuSignClient.cs
@@ -220,9 +220,9 @@ namespace DocuSign.Monitor.Client
         /// <value>An instance of the RestClient</value>
         public IHttpClient RestClient { get; set; }
 
-        public DocuSignRequest PrepareOAuthRequest(string oAuthBasePath, string path, HttpMethod method, List<KeyValuePair<string, string>> headerParams = null, List<KeyValuePair<string, string>> formParams = null)
+        public DocuSignRequest PrepareOAuthRequest(string oAuthBasePathParam, string path, HttpMethod method, List<KeyValuePair<string, string>> headerParams = null, List<KeyValuePair<string, string>> formParams = null)
         {
-            string url = $"https://{oAuthBasePath}/{path}";
+            string url = $"https://{oAuthBasePathParam}/{path}";
             
             if (!headerParams.Any(kvp => kvp.Key?.Equals("Content-Type") ?? false)) { headerParams.Add(new KeyValuePair<string, string>("Content-Type", "application/x-www-form-urlencoded")); }
             if (!headerParams.Any(kvp => kvp.Key?.Equals("Cache-Control") ?? false)) { headerParams.Add(new KeyValuePair<string, string>("Cache-Control", "no-store")); }
@@ -914,7 +914,7 @@ namespace DocuSign.Monitor.Client
             if (localVarHeaderParams.ContainsKey("Authorization")) { localVarHeaderParams.Remove("Authorization"); }
             localVarHeaderParams.Add("Authorization", "Bearer " + accessToken);
 
-            DocuSignRequest request = PrepareOAuthRequest(oAuthBasePath, $"oauth/userinfo", HttpMethod.Get, localVarHeaderParams.ToList(), localVarFormParams.ToList());
+            DocuSignRequest request = PrepareOAuthRequest(this.oAuthBasePath, $"oauth/userinfo", HttpMethod.Get, localVarHeaderParams.ToList(), localVarFormParams.ToList());
             DocuSignResponse response = await RestClient.SendRequestAsync(request, cancellationToken);
 
             if (response.StatusCode >= HttpStatusCode.OK && response.StatusCode < HttpStatusCode.BadRequest)
@@ -964,7 +964,7 @@ namespace DocuSign.Monitor.Client
         /// </summary>
         /// <param name="clientId">Docusign OAuth Client Id(AKA Integrator Key)</param>
         /// <param name="userId">Docusign user Id to be impersonated(This is a UUID)</param>
-        /// <param name="oauthBasePath"> Docusign OAuth base path
+        /// <param name="oAuthBasePathParam"> Docusign OAuth base path
         /// <see cref="OAuth.Demo_OAuth_BasePath"/> <see cref="OAuth.Production_OAuth_BasePath"/>
         /// <seealso cref="GetOAuthBasePath()" /> <seealso cref="SetOAuthBasePath(string)"/>
         /// </param>
@@ -974,12 +974,12 @@ namespace DocuSign.Monitor.Client
         /// <see cref="OAuth.Scope_SIGNATURE"/> <see cref="OAuth.Scope_IMPERSONATION"/> <see cref="OAuth.Scope_EXTENDED"/>
         /// </param>
         /// <returns>The JWT user token</returns>
-        public OAuth.OAuthToken RequestJWTUserToken(string clientId, string userId, string oauthBasePath, Stream privateKeyStream, int expiresInHours, List<string> scopes = null)
+        public OAuth.OAuthToken RequestJWTUserToken(string clientId, string userId, string oAuthBasePathParam, Stream privateKeyStream, int expiresInHours, List<string> scopes = null)
         {
             using (var cts = new CancellationTokenSource())
             {              
                 return TryCatchWrapper(() => {
-                    var task = Task.Run(async () => await RequestJWTUserTokenAsync(clientId, userId, oauthBasePath, privateKeyStream, expiresInHours, scopes, cts.Token));
+                    var task = Task.Run(async () => await RequestJWTUserTokenAsync(clientId, userId, oAuthBasePathParam, privateKeyStream, expiresInHours, scopes, cts.Token));
                     task.Wait();
                     return task.Result;
                 });
@@ -992,7 +992,7 @@ namespace DocuSign.Monitor.Client
         /// </summary>
         /// <param name="clientId">Docusign OAuth Client Id(AKA Integrator Key)</param>
         /// <param name="userId">Docusign user Id to be impersonated(This is a UUID)</param>
-        /// <param name="oauthBasePath"> Docusign OAuth base path
+        /// <param name="oAuthBasePathParam"> Docusign OAuth base path
         /// <see cref="OAuth.Demo_OAuth_BasePath"/> <see cref="OAuth.Production_OAuth_BasePath"/>
         /// <seealso cref="GetOAuthBasePath()" /> <seealso cref="SetOAuthBasePath(string)"/>
         /// </param>
@@ -1003,12 +1003,12 @@ namespace DocuSign.Monitor.Client
         /// <see cref="OAuth.Scope_SIGNATURE"/> <see cref="OAuth.Scope_IMPERSONATION"/> <see cref="OAuth.Scope_EXTENDED"/>
         /// </param>
         /// <returns>The JWT user token</returns>
-        public async Task<OAuth.OAuthToken> RequestJWTUserTokenAsync(string clientId, string userId, string oauthBasePath, Stream privateKeyStream, int expiresInHours, List<string> scopes = null, CancellationToken cancellationToken = default)
+        public async Task<OAuth.OAuthToken> RequestJWTUserTokenAsync(string clientId, string userId, string oAuthBasePathParam, Stream privateKeyStream, int expiresInHours, List<string> scopes = null, CancellationToken cancellationToken = default)
         {
             if (privateKeyStream != null && privateKeyStream.CanRead && privateKeyStream.Length > 0)
             {
                 byte[] privateKeyBytes = ReadAsBytes(privateKeyStream);
-                return await this.RequestJWTUserTokenAsync(clientId, userId, oauthBasePath, privateKeyBytes, expiresInHours, scopes, cancellationToken);
+                return await this.RequestJWTUserTokenAsync(clientId, userId, oAuthBasePathParam, privateKeyBytes, expiresInHours, scopes, cancellationToken);
             }
             else
             {
@@ -1022,7 +1022,7 @@ namespace DocuSign.Monitor.Client
         /// </summary>
         /// <param name="clientId">Docusign OAuth Client Id(AKA Integrator Key)</param>
         /// <param name="userId">Docusign user Id to be impersonated(This is a UUID)</param>
-        /// <param name="oauthBasePath"> Docusign OAuth base path
+        /// <param name="oAuthBasePathParam"> Docusign OAuth base path
         /// <see cref="OAuth.Demo_OAuth_BasePath"/> <see cref="OAuth.Production_OAuth_BasePath"/>
         /// <seealso cref="GetOAuthBasePath()" /> <seealso cref="SetOAuthBasePath(string)"/>
         /// </param>
@@ -1032,13 +1032,13 @@ namespace DocuSign.Monitor.Client
         /// <see cref="OAuth.Scope_SIGNATURE"/> <see cref="OAuth.Scope_IMPERSONATION"/> <see cref="OAuth.Scope_EXTENDED"/>
         /// </param>
         /// <returns>The JWT user token</returns>
-        public OAuth.OAuthToken RequestJWTUserToken(string clientId, string userId, string oauthBasePath, byte[] privateKeyBytes, int expiresInHours, List<string> scopes = null)
+        public OAuth.OAuthToken RequestJWTUserToken(string clientId, string userId, string oAuthBasePathParam, byte[] privateKeyBytes, int expiresInHours, List<string> scopes = null)
         {
 
             using (var cts = new CancellationTokenSource())
             {              
                 return TryCatchWrapper(() => {
-                    var task = Task.Run(async () => await RequestJWTUserTokenAsync(clientId, userId, oauthBasePath, privateKeyBytes, expiresInHours, scopes, cts.Token));
+                    var task = Task.Run(async () => await RequestJWTUserTokenAsync(clientId, userId, oAuthBasePathParam, privateKeyBytes, expiresInHours, scopes, cts.Token));
                     task.Wait();
                     return task.Result;
                 });
@@ -1051,7 +1051,7 @@ namespace DocuSign.Monitor.Client
         /// </summary>
         /// <param name="clientId">Docusign OAuth Client Id(AKA Integrator Key)</param>
         /// <param name="userId">Docusign user Id to be impersonated(This is a UUID)</param>
-        /// <param name="oauthBasePath"> Docusign OAuth base path
+        /// <param name="oAuthBasePathParam"> Docusign OAuth base path
         /// <see cref="OAuth.Demo_OAuth_BasePath"/> <see cref="OAuth.Production_OAuth_BasePath"/>
         /// <seealso cref="GetOAuthBasePath()" /> <seealso cref="SetOAuthBasePath(string)"/>
         /// </param>
@@ -1062,7 +1062,7 @@ namespace DocuSign.Monitor.Client
         /// <see cref="OAuth.Scope_SIGNATURE"/> <see cref="OAuth.Scope_IMPERSONATION"/> <see cref="OAuth.Scope_EXTENDED"/>
         /// </param>
         /// <returns>The JWT user token</returns>
-        public async Task<OAuth.OAuthToken> RequestJWTUserTokenAsync(string clientId, string userId, string oauthBasePath, byte[] privateKeyBytes, int expiresInHours, List<string> scopes = null, CancellationToken cancellationToken = default)
+        public async Task<OAuth.OAuthToken> RequestJWTUserTokenAsync(string clientId, string userId, string oAuthBasePathParam, byte[] privateKeyBytes, int expiresInHours, List<string> scopes = null, CancellationToken cancellationToken = default)
         {
             string privateKey = Encoding.UTF8.GetString(privateKeyBytes);
 
@@ -1081,7 +1081,7 @@ namespace DocuSign.Monitor.Client
 
             descriptor.Subject = new ClaimsIdentity();
             descriptor.Subject.AddClaim(new Claim("scope", String.Join(" ", scopes)));
-            descriptor.Subject.AddClaim(new Claim("aud", oauthBasePath));
+            descriptor.Subject.AddClaim(new Claim("aud", oAuthBasePathParam));
             descriptor.Subject.AddClaim(new Claim("iss", clientId));
 
             if (!string.IsNullOrEmpty(userId))
@@ -1112,7 +1112,7 @@ namespace DocuSign.Monitor.Client
                 { "assertion", jwtToken }
             };
 
-            DocuSignRequest request = PrepareOAuthRequest(oauthBasePath, $"oauth/token", HttpMethod.Post, Configuration.DefaultHeader?.ToList(), localVarFormParams.ToList());
+            DocuSignRequest request = PrepareOAuthRequest(oAuthBasePathParam, $"oauth/token", HttpMethod.Post, Configuration.DefaultHeader?.ToList(), localVarFormParams.ToList());
             DocuSignResponse response = await RestClient.SendRequestAsync(request, cancellationToken);
 
             if (response.StatusCode >= HttpStatusCode.OK && response.StatusCode < HttpStatusCode.BadRequest)
@@ -1132,7 +1132,7 @@ namespace DocuSign.Monitor.Client
         /// *RESERVED FOR PARTNERS* RequestJWTApplicationToken
         /// </summary>
         /// <param name="clientId">Docusign OAuth Client Id(AKA Integrator Key)</param>
-        /// <param name="oauthBasePath"> Docusign OAuth base path
+        /// <param name="oAuthBasePathParam"> Docusign OAuth base path
         /// <see cref="OAuth.Demo_OAuth_BasePath"/> <see cref="OAuth.Production_OAuth_BasePath"/>
         /// <seealso cref="GetOAuthBasePath()" /> <seealso cref="SetOAuthBasePath(string)"/>
         /// </param>
@@ -1142,12 +1142,12 @@ namespace DocuSign.Monitor.Client
         /// <see cref="OAuth.Scope_SIGNATURE"/> <see cref="OAuth.Scope_IMPERSONATION"/> <see cref="OAuth.Scope_EXTENDED"/>
         /// </param>
         /// <returns>The JWT application token</returns>
-        public OAuth.OAuthToken RequestJWTApplicationToken(string clientId, string oauthBasePath, byte[] privateKeyBytes, int expiresInHours, List<string> scopes = null)
+        public OAuth.OAuthToken RequestJWTApplicationToken(string clientId, string oAuthBasePathParam, byte[] privateKeyBytes, int expiresInHours, List<string> scopes = null)
         {
             using (var cts = new CancellationTokenSource())
             {              
                 return TryCatchWrapper(() => {
-                    var task = Task.Run(async () => await RequestJWTApplicationTokenAsync(clientId, oAuthBasePath, privateKeyBytes, expiresInHours, scopes, cts.Token));
+                    var task = Task.Run(async () => await RequestJWTApplicationTokenAsync(clientId, oAuthBasePathParam, privateKeyBytes, expiresInHours, scopes, cts.Token));
                     task.Wait();
                     return task.Result;
                 });
@@ -1158,7 +1158,7 @@ namespace DocuSign.Monitor.Client
         /// *RESERVED FOR PARTNERS* RequestJWTApplicationTokenAsync
         /// </summary>
         /// <param name="clientId">Docusign OAuth Client Id(AKA Integrator Key)</param>
-        /// <param name="oauthBasePath"> Docusign OAuth base path
+        /// <param name="oAuthBasePathParam"> Docusign OAuth base path
         /// <see cref="OAuth.Demo_OAuth_BasePath"/> <see cref="OAuth.Production_OAuth_BasePath"/>
         /// <seealso cref="GetOAuthBasePath()" /> <seealso cref="SetOAuthBasePath(string)"/>
         /// </param>
@@ -1169,7 +1169,7 @@ namespace DocuSign.Monitor.Client
         /// <see cref="OAuth.Scope_SIGNATURE"/> <see cref="OAuth.Scope_IMPERSONATION"/> <see cref="OAuth.Scope_EXTENDED"/>
         /// </param>
         /// <returns>The JWT application token</returns>
-        public async Task<OAuth.OAuthToken> RequestJWTApplicationTokenAsync(string clientId, string oauthBasePath, byte[] privateKeyBytes, int expiresInHours, List<string> scopes = null, CancellationToken cancellationToken = default)
+        public async Task<OAuth.OAuthToken> RequestJWTApplicationTokenAsync(string clientId, string oAuthBasePathParam, byte[] privateKeyBytes, int expiresInHours, List<string> scopes = null, CancellationToken cancellationToken = default)
         {
             string privateKey = Encoding.UTF8.GetString(privateKeyBytes);
 
@@ -1184,7 +1184,7 @@ namespace DocuSign.Monitor.Client
 
             descriptor.Subject = new ClaimsIdentity();
             descriptor.Subject.AddClaim(new Claim("scope", String.Join(" ", scopes)));
-            descriptor.Subject.AddClaim(new Claim("aud", oauthBasePath));
+            descriptor.Subject.AddClaim(new Claim("aud", oAuthBasePathParam));
             descriptor.Subject.AddClaim(new Claim("iss", clientId));
 
             if (!string.IsNullOrEmpty(privateKey))
@@ -1206,7 +1206,7 @@ namespace DocuSign.Monitor.Client
                 { "assertion", jwtToken }
             };
 
-            DocuSignRequest request = PrepareOAuthRequest(oauthBasePath, $"oauth/token", HttpMethod.Post, Configuration.DefaultHeader?.ToList(), localVarFormParams.ToList());
+            DocuSignRequest request = PrepareOAuthRequest(oAuthBasePathParam, $"oauth/token", HttpMethod.Post, Configuration.DefaultHeader?.ToList(), localVarFormParams.ToList());
             DocuSignResponse response = await RestClient.SendRequestAsync(request, cancellationToken);
 
             if (response.StatusCode >= HttpStatusCode.OK && response.StatusCode < HttpStatusCode.BadRequest)

--- a/sdk/src/DocuSign.Monitor/DocuSign.Monitor.csproj
+++ b/sdk/src/DocuSign.Monitor/DocuSign.Monitor.csproj
@@ -16,7 +16,7 @@
     <RootNamespace>DocuSign.Monitor</RootNamespace>
     <AssemblyName>DocuSign.Monitor</AssemblyName>
     <NeutralLanguage>en-US</NeutralLanguage>
-    <VersionPrefix>2.0.1</VersionPrefix>
+    <VersionPrefix>2.0.2</VersionPrefix>
     <VersionSuffix/>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -26,7 +26,7 @@
     <PackageLicenseUrl>https://github.com/docusign/docusign-monitor-csharp-client/blob/master/LICENSE</PackageLicenseUrl>
     <RepositoryUrl>https://github.com/docusign/docusign-monitor-csharp-client</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <PackageReleaseNotes>[v2.0.1] - Monitor API v2.0-2.0.0 - 11/7/2024</PackageReleaseNotes>
+    <PackageReleaseNotes>[v2.0.2] - Monitor API v2.0-2.0.0 - 11/15/2024</PackageReleaseNotes>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net462'">
     <DefineConstants>NET462</DefineConstants>
@@ -38,10 +38,10 @@
     <Reference Include="System.Web"/>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="7.5.2"/>
+    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.2.0"/>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3"/>
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0"/>
-    <PackageReference Include="BouncyCastle.Cryptography" Version="2.3.1"/>
+    <PackageReference Include="BouncyCastle.Cryptography" Version="2.4.0"/>
   </ItemGroup>
   <ItemGroup/>
 </Project>

--- a/sdk/src/DocuSign.Monitor/Properties/AssemblyInfo.cs
+++ b/sdk/src/DocuSign.Monitor/Properties/AssemblyInfo.cs
@@ -22,5 +22,5 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 internal class AssemblyInformation
 {
-    public const string AssemblyInformationalVersion = "2.0.1";
+    public const string AssemblyInformationalVersion = "2.0.2";
 }

--- a/test/SdkNetCoreTests/SdkNetCoreTests.csproj
+++ b/test/SdkNetCoreTests/SdkNetCoreTests.csproj
@@ -13,8 +13,8 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="7.5.2" />
-		<PackageReference Include="BouncyCastle.Cryptography" Version="2.3.1" />
+		<PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.2.0" />
+		<PackageReference Include="BouncyCastle.Cryptography" Version="2.4.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/test/SdkTests/SdkTests.csproj
+++ b/test/SdkTests/SdkTests.csproj
@@ -43,29 +43,32 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="BouncyCastle.Cryptography, Version=2.0.0.0, Culture=neutral, PublicKeyToken=072edcf4a5328938, processorArchitecture=MSIL">
-      <HintPath>..\packages\BouncyCastle.Cryptography.2.3.1\lib\net461\BouncyCastle.Cryptography.dll</HintPath>
+      <HintPath>..\packages\BouncyCastle.Cryptography.2.4.0\lib\net461\BouncyCastle.Cryptography.dll</HintPath>
     </Reference>
     <Reference Include="DocuSign.Monitor">
       <HintPath>..\..\sdk\src\DocuSign.Monitor\bin\Debug\net462\DocuSign.Monitor.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=1.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Bcl.AsyncInterfaces.1.1.0\lib\net461\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
+    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bcl.AsyncInterfaces.8.0.0\lib\net462\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Bcl.TimeProvider, Version=8.0.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bcl.TimeProvider.8.0.1\lib\net462\Microsoft.Bcl.TimeProvider.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Microsoft.IdentityModel.Abstractions, Version=7.5.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.IdentityModel.Abstractions.7.5.2\lib\net472\Microsoft.IdentityModel.Abstractions.dll</HintPath>
+    <Reference Include="Microsoft.IdentityModel.Abstractions, Version=8.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.IdentityModel.Abstractions.8.2.0\lib\net472\Microsoft.IdentityModel.Abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.IdentityModel.JsonWebTokens, Version=7.5.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.IdentityModel.JsonWebTokens.7.5.2\lib\net472\Microsoft.IdentityModel.JsonWebTokens.dll</HintPath>
+    <Reference Include="Microsoft.IdentityModel.JsonWebTokens, Version=8.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.IdentityModel.JsonWebTokens.8.2.0\lib\net472\Microsoft.IdentityModel.JsonWebTokens.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.IdentityModel.Logging, Version=7.5.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.IdentityModel.Logging.7.5.2\lib\net472\Microsoft.IdentityModel.Logging.dll</HintPath>
+    <Reference Include="Microsoft.IdentityModel.Logging, Version=8.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.IdentityModel.Logging.8.2.0\lib\net472\Microsoft.IdentityModel.Logging.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.IdentityModel.Protocols, Version=7.3.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.IdentityModel.Protocols.7.3.1\lib\net472\Microsoft.IdentityModel.Protocols.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.IdentityModel.Tokens, Version=7.5.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.IdentityModel.Tokens.7.5.2\lib\net472\Microsoft.IdentityModel.Tokens.dll</HintPath>
+    <Reference Include="Microsoft.IdentityModel.Tokens, Version=8.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.IdentityModel.Tokens.8.2.0\lib\net472\Microsoft.IdentityModel.Tokens.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\MSTest.TestFramework.2.1.2\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
@@ -100,15 +103,15 @@
     <Reference Include="System.Numerics.Vectors, Version=4.1.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Numerics.Vectors.4.5.0\lib\net46\System.Numerics.Vectors.dll</HintPath>
     </Reference>
-    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.6.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.7.1\lib\net461\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.6.0.0\lib\net461\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime.Serialization" />
-    <Reference Include="System.Text.Encodings.Web, Version=4.0.5.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Text.Encodings.Web.4.7.2\lib\net461\System.Text.Encodings.Web.dll</HintPath>
+    <Reference Include="System.Text.Encodings.Web, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Text.Encodings.Web.8.0.0\lib\net462\System.Text.Encodings.Web.dll</HintPath>
     </Reference>
-    <Reference Include="System.Text.Json, Version=4.0.1.2, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Text.Json.4.7.2\lib\net461\System.Text.Json.dll</HintPath>
+    <Reference Include="System.Text.Json, Version=8.0.0.5, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Text.Json.8.0.5\lib\net462\System.Text.Json.dll</HintPath>
     </Reference>
     <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Threading.Tasks.Extensions.4.5.4\lib\net461\System.Threading.Tasks.Extensions.dll</HintPath>

--- a/test/SdkTests/app.config
+++ b/test/SdkTests/app.config
@@ -32,7 +32,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.6.0" newVersion="4.0.6.0" />
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />

--- a/test/SdkTests/packages.config
+++ b/test/SdkTests/packages.config
@@ -1,20 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="BouncyCastle.Cryptography" version="2.3.1" targetFramework="net472" />
-  <package id="Microsoft.Bcl.AsyncInterfaces" version="1.1.0" targetFramework="net472" />
+  <package id="BouncyCastle.Cryptography" version="2.4.0" targetFramework="net472" />
+  <package id="Microsoft.Bcl.AsyncInterfaces" version="8.0.0" targetFramework="net472" />
+  <package id="Microsoft.Bcl.TimeProvider" version="8.0.1" targetFramework="net472" />
   <package id="Microsoft.CSharp" version="4.7.0" targetFramework="net472" />
-  <package id="Microsoft.IdentityModel.Abstractions" version="7.5.2" targetFramework="net472" />
-  <package id="Microsoft.IdentityModel.JsonWebTokens" version="7.5.2" targetFramework="net472" />
-  <package id="Microsoft.IdentityModel.Logging" version="7.5.2" targetFramework="net472" />
-  <package id="Microsoft.IdentityModel.Tokens" version="7.5.2" targetFramework="net472" />
+  <package id="Microsoft.IdentityModel.Abstractions" version="8.2.0" targetFramework="net472" />
+  <package id="Microsoft.IdentityModel.JsonWebTokens" version="8.2.0" targetFramework="net472" />
+  <package id="Microsoft.IdentityModel.Logging" version="8.2.0" targetFramework="net472" />
+  <package id="Microsoft.IdentityModel.Tokens" version="8.2.0" targetFramework="net472" />
   <package id="MSTest.TestAdapter" version="2.1.2" targetFramework="net47" />
   <package id="MSTest.TestFramework" version="2.1.2" targetFramework="net47" />
   <package id="System.Buffers" version="4.5.1" targetFramework="net472" />
   <package id="System.Memory" version="4.5.5" targetFramework="net472" />
   <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net472" />
-  <package id="System.Runtime.CompilerServices.Unsafe" version="4.7.1" targetFramework="net472" />
-  <package id="System.Text.Encodings.Web" version="4.7.2" targetFramework="net472" />
-  <package id="System.Text.Json" version="4.7.2" targetFramework="net472" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="6.0.0" targetFramework="net472" />
+  <package id="System.Text.Encodings.Web" version="8.0.0" targetFramework="net472" />
+  <package id="System.Text.Json" version="8.0.5" targetFramework="net472" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net472" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net472" />
 </packages>


### PR DESCRIPTION
### Changed
- Resolved an issue that prevented the use of `RequestJWTApplicationToken` with a production account URL.
- Updated C# SDK dependencies.
    - BouncyCastle.Cryptography: Version bumped from 2.3.1 to 2.4.0.
    - Microsoft.IdentityModelJsonWebTokens: Version bumped from 7.5.2 to 8.2.0.
- Updated the SDK release version.
